### PR TITLE
Configure Netlify build for Next.js

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
-  NPM_FLAGS = "--version"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
 


### PR DESCRIPTION
## Summary
- use Netlify's Next.js plugin for correct build output
- remove NPM_FLAGS override so Netlify installs dependencies

## Testing
- `pnpm lint` (fails: command asked for interactive configuration)
- `pnpm build` (fails: could not fetch Google fonts)

------
https://chatgpt.com/codex/tasks/task_e_68b1813acddc8324a3505b1f39684748